### PR TITLE
Add 'changed' status to varGetValue

### DIFF
--- a/VarTools.typ
+++ b/VarTools.typ
@@ -55,5 +55,6 @@ TYPE
 		dataType : UDINT;
 		length : UDINT;
 		dimension : UINT;
+		changed : BOOL;
 	END_STRUCT;
 END_TYPE

--- a/varGetValueLreal.c
+++ b/varGetValueLreal.c
@@ -161,7 +161,7 @@ switch( ipVariable->dataType ){
 			// We do not have a brwatof function
 			// So instead convert to string then use brsatof
 			char tempString[25]; // Max number of characters of a double is 24
-			wstring2string((UDINT)tempString, ipVariable->address, sizeof(tempString));
+			wstring2string( (UDINT)tempString, ipVariable->address, sizeof(tempString) );
 	
 			*(LREAL*)pValue = brsatod((UDINT)tempString); 
 	

--- a/varGetValueReal.c
+++ b/varGetValueReal.c
@@ -157,7 +157,7 @@ switch( ipVariable->dataType ){
 			// We do not have a brwatof function
 			// So instead convert to string then use brsatof
 			char tempString[25]; // Max number of characters of a double is 24
-			wstring2string((UDINT)tempString, ipVariable->address, sizeof(tempString));
+			wstring2string( (UDINT)tempString, ipVariable->address, sizeof(tempString));
 	
 			*(REAL*)pValue = brsatof((UDINT)tempString); 
 	

--- a/varSetValue.c
+++ b/varSetValue.c
@@ -371,7 +371,7 @@ unsigned short varSetValue(unsigned long pVariable)
 		
 		case VAR_TYPE_WSTRING: 
 			
-			string2wstring( (UDINT)ipVariable->address, (UDINT)ipVariable->value, ipVariable->length-1 );
+			string2wstring( ipVariable->address, (UDINT)ipVariable->value, ipVariable->length-1 );
 		
 			break;
 	


### PR DESCRIPTION
## Important notes:

1. (w)Strings with lengths longer than VAR_STRLEN_NAME (120) chars will only report on change if its in the first 120 chars
2. This increases the stack size of call by VAR_STRLEN_NAME (120) + UDINT (4) bytes 
3. This increases cpu usage of the call by about 1 strlen (max 120 chars) and 1 strcmp (max 120 chars)