### PR TITLE
Fix: register VarTools LibraryObject in Cpu.sw to fix broken publish

### DIFF
--- a/example/AsProject/Physical/ARM/X20CP0484/Cpu.sw
+++ b/example/AsProject/Physical/ARM/X20CP0484/Cpu.sw
@@ -10,6 +10,39 @@
   <TaskClass Name="Cyclic#7" />
   <TaskClass Name="Cyclic#8" />
   <Libraries>
+    <LibraryObject Name="ArEventLog" Source="Libraries._AS.ArEventLog.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsARCfg" Source="Libraries._AS.AsARCfg.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsArProf" Source="Libraries._AS.AsArProf.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsBrMath" Source="Libraries._AS.AsBrMath.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsBrStr" Source="Libraries._AS.AsBrStr.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsBrWStr" Source="Libraries._AS.AsBrWStr.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsEPL" Source="Libraries._AS.AsEPL.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsGuard" Source="Libraries._AS.AsGuard.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsHttp" Source="Libraries._AS.AsHttp.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsIO" Source="Libraries._AS.AsIO.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsIOAcc" Source="Libraries._AS.AsIOAcc.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsIODiag" Source="Libraries._AS.AsIODiag.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsIOTime" Source="Libraries._AS.AsIOTime.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsMem" Source="Libraries._AS.AsMem.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsSem" Source="Libraries._AS.AsSem.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsTCP" Source="Libraries._AS.AsTCP.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsUDP" Source="Libraries._AS.AsUDP.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsUSB" Source="Libraries._AS.AsUSB.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsXml" Source="Libraries._AS.AsXml.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsZip" Source="Libraries._AS.AsZip.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="astime" Source="Libraries._AS.astime.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="brsystem" Source="Libraries._AS.brsystem.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="DataObj" Source="Libraries._AS.DataObj.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="dvframe" Source="Libraries._AS.dvframe.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="FileIO" Source="Libraries._AS.FileIO.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="LoopConR" Source="Libraries._AS.LoopConR.lby" Memory="UserROM" Language="Binary" Debugging="true" />
+    <LibraryObject Name="MTBasics" Source="Libraries._AS.MTBasics.lby" Memory="UserROM" Language="Binary" Debugging="true" />
+    <LibraryObject Name="MTLookUp" Source="Libraries._AS.MTLookUp.lby" Memory="UserROM" Language="Binary" Debugging="true" />
+    <LibraryObject Name="MTTypes" Source="Libraries._AS.MTTypes.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="operator" Source="Libraries._AS.operator.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="runtime" Source="Libraries._AS.runtime.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="standard" Source="Libraries._AS.standard.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="sys_lib" Source="Libraries._AS.sys_lib.lby" Memory="UserROM" Language="binary" Debugging="true" />
     <LibraryObject Name="stringext" Source="Libraries.Loupe.stringext.lby" Memory="UserROM" Language="Binary" Debugging="true" />
     <LibraryObject Name="VarTools" Source="Libraries.Loupe.VarTools.lby" Memory="UserROM" Language="ANSIC" Debugging="true" />
   </Libraries>

--- a/example/AsProject/Physical/ARM/X20CP0484/Cpu.sw
+++ b/example/AsProject/Physical/ARM/X20CP0484/Cpu.sw
@@ -1,3 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?AutomationStudio FileVersion="4.9"?>
-<SwConfiguration CpuAddress="" xmlns="http://br-automation.co.at/AS/SwConfiguration" />
+<SwConfiguration CpuAddress="" xmlns="http://br-automation.co.at/AS/SwConfiguration">
+  <TaskClass Name="Cyclic#1" />
+  <TaskClass Name="Cyclic#2" />
+  <TaskClass Name="Cyclic#3" />
+  <TaskClass Name="Cyclic#4" />
+  <TaskClass Name="Cyclic#5" />
+  <TaskClass Name="Cyclic#6" />
+  <TaskClass Name="Cyclic#7" />
+  <TaskClass Name="Cyclic#8" />
+  <Libraries>
+    <LibraryObject Name="stringext" Source="Libraries.Loupe.stringext.lby" Memory="UserROM" Language="Binary" Debugging="true" />
+    <LibraryObject Name="VarTools" Source="Libraries.Loupe.VarTools.lby" Memory="UserROM" Language="ANSIC" Debugging="true" />
+  </Libraries>
+</SwConfiguration>

--- a/example/AsProject/Physical/Intel/5APC4100_TGL1_000/Cpu.sw
+++ b/example/AsProject/Physical/Intel/5APC4100_TGL1_000/Cpu.sw
@@ -56,5 +56,7 @@
     <LibraryObject Name="MTBasics" Source="Libraries._AS.MTBasics.lby" Memory="UserROM" Language="binary" Debugging="true" />
     <LibraryObject Name="LoopConR" Source="Libraries._AS.LoopConR.lby" Memory="UserROM" Language="Binary" Debugging="true" />
     <LibraryObject Name="MTLookUp" Source="Libraries._AS.MTLookUp.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="stringext" Source="Libraries.Loupe.stringext.lby" Memory="UserROM" Language="Binary" Debugging="true" />
+    <LibraryObject Name="VarTools" Source="Libraries.Loupe.VarTools.lby" Memory="UserROM" Language="ANSIC" Debugging="true" />
   </Libraries>
 </SwConfiguration>


### PR DESCRIPTION
## What
Adds a `<LibraryObject Name="VarTools" .../>` entry to both `Cpu.sw` files (Intel + ARM). Also expands the previously self-closing `<SwConfiguration .../>` ARM Cpu.sw to a proper structure (TaskClass#1-8 + Libraries block). Adds a missing stringext LibraryObject too (also wasn't registered).

## Why
`@loupeteam/vartools@1.0.0` was published missing all `.br` files (only `libVarTools.a` for ARM). Downstream consumers (Chopper, OMJSON, OMSQL, Chopper, atn, etc.) fail at build time with `error 427: Needed module vartools of required range from 1.0.0 ... not installed`.

Root cause: without the lib being developed registered as a `<LibraryObject>` in the configuration's `Cpu.sw`, AS6 compiles the lib's `.a` but doesn't include it in the configuration's runtime image, so no `.br` is generated. The export-as-library action then ships only the `.a`, producing a broken tarball.

This is the same class of bug as LogThat#5, but the trigger is different (incomplete `Cpu.sw`, not wrong `LIBRARY` env var).

## Verification
After this change, `Temp/Objects/Intel/.../VarTools.br` and `Temp/Objects/ARM/.../VarTools.br` are both produced. Intel + ARM builds clean (only the benign `447` licensing warning).

## Follow-up
Once merged:
1. Delete the broken `@loupeteam/vartools@1.0.0` GitHub Package version (manual, requires `delete:packages` scope)
2. Trigger `build-export-publish.yml` workflow with version `v1.0.0` to republish

## Related
- DirIOWrap, DatObjWrap, Persist have the same bug — separate fix PRs incoming
- `UPGRADE_TO_AS6.md` step 7c now requires this LibraryObject entry for all migrations going forward